### PR TITLE
Userテーブルのtablename変更

### DIFF
--- a/fast_api/models.py
+++ b/fast_api/models.py
@@ -12,7 +12,7 @@ class Todo(Base):
 
 
 class User(Base):
-    __tablename__ = "user"
+    __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String)


### PR DESCRIPTION
### 関連するIssue
close #11 

### 説明
fast_api/models.pyのテーブル名をuserからusersに変更。

### 上記追加以外の変更点
特になし

### 確認したこと
- FastAPIが正常に起動し、docsのテスト送信でエラーが起きないことを確認












