### PR TITLE
todoの全件取得の実装

### DIFF
--- a/fast_api/routers/route_todo.py
+++ b/fast_api/routers/route_todo.py
@@ -13,7 +13,7 @@ router = APIRouter()
 auth = AuthJwtCsrf()
 
 
-@router.post("/api/todo/", response_model=schemas.Todo)
+@router.post("/api/todo", response_model=schemas.Todo)
 def create_todo(request: Request, response: Response,
                 todo: schemas.TodoCreate,
                 db: Session = Depends(get_db),
@@ -32,7 +32,7 @@ def create_todo(request: Request, response: Response,
     raise HTTPException(status_code=404, detail="Create task faild")
 
 
-@router.get("/api/todo/", response_model=list[schemas.Todo])
+@router.get("/api/todo", response_model=list[schemas.Todo])
 def read_todos(request: Request,
                skip: int = 0, limit: int = 100,
                db: Session = Depends(get_db)):

--- a/react_farm/src/components/Todo.tsx
+++ b/react_farm/src/components/Todo.tsx
@@ -1,14 +1,18 @@
-import { FC } from 'react';
-import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/solid';
+import { ArrowRightOnRectangleIcon as LogoutIcon } from '@heroicons/react/24/solid';
 import { useProcessAuth } from '../hooks/useProcessAuth';
+import { useQueryTasks } from '../hooks/useQueryTasks';
+import { useQueryUser } from '../hooks/useQueryUser';
 
-export const Todo: FC = () => {
+export const Todo = () => {
   const { logout } = useProcessAuth()
+  const { data: dataUser } = useQueryUser()
+  const { data: dataTasks, isLoading: isLoadingTasks } = useQueryTasks()
+
   return (
     <div className="flex justify-center items-center flex-col min-h-screen text-gray-600 font-mono">
-      <ArrowRightOnRectangleIcon
+      <LogoutIcon
         onClick={logout}
-        className="h-7 w-7 mt-1 mb-5 text-vlue-500 cursor-pointer"
+        className="h-7 w-7 mt-1 mb-5 text-blue-500 cursor-pointer"
       />
     </div>
   )

--- a/react_farm/src/hooks/useQueryTasks.ts
+++ b/react_farm/src/hooks/useQueryTasks.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "react-query"
+import axios from "axios"
+import { Task } from "../types/types"
+
+export const useQueryTasks = () => {
+  const getTasks = async () => {
+    const { data } = await axios.get<Task[]>(
+      `${process.env.REACT_APP_API_URL}/todo`,
+      {
+        withCredentials: true,
+      }
+    )
+    return data
+  }
+  return useQuery<Task[], Error>({
+    queryKey: "tasks",
+    queryFn: getTasks,
+    staleTime: Infinity,
+  })
+}

--- a/react_farm/src/hooks/useQueryUser.ts
+++ b/react_farm/src/hooks/useQueryUser.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "react-query"
+import axios from "axios"
+import { UserInfo } from "../types/types"
+import { useNavigate } from "react-router-dom"
+
+export const useQueryUser = () => {
+  const navigate = useNavigate()
+  const getCurrentUser = async () => {
+    const { data } = await axios.get<UserInfo>(
+      `${process.env.REACT_APP_API_URL}/user`,
+      {
+        withCredentials: true,
+      }
+    )
+    return data
+  }
+  return useQuery({
+    queryKey: "user",
+    queryFn: getCurrentUser,
+    staleTime: Infinity,
+    onError: () => navigate("/"),
+  })
+}


### PR DESCRIPTION
### 関連するIssue
close #7 

### 説明
ログインするとtodoを全件取得し、cookieに保存する機能の実装。ログインユーザの情報もcookieに保存される

### 上記追加以外の変更点
ログイン時に2回todoの取得を行っていたため、`fast_api/route_todo`に記載されているパスを`/api/todo/`から`/api/todo`に修正

### 確認したこと
- ログイン時、todo全件とuserがそれぞれ`todos`と`user`という名前でcookieに保存されることを確認

### 備考
初期画面表示時、csrfトークンを2回取得していることをディベロッパーツールのネットワークから確認した。動作上問題ないので対応は後ほどやる予定。issueは #14 で発行済み 