### PR TITLE
タスク一覧画面の作成

### DIFF
--- a/react_farm/src/components/TaskItem.tsx
+++ b/react_farm/src/components/TaskItem.tsx
@@ -1,0 +1,39 @@
+import React, { FC, memo } from "react";
+import { PencilSquareIcon, TrashIcon } from "@heroicons/react/24/solid";
+import { Task } from "../types/types";
+import { useAppDispatch } from "../app/hooks";
+import { setEditedTask } from "../slices/appSlice";
+import { useMutateTask } from "../hooks/useMutateTask";
+
+const TaskItemMemo: FC<Task> = ({ id, title, description }) => {
+  const dispatch = useAppDispatch()
+  const { deleteTaskMutation } = useMutateTask()
+  return (
+    <li>
+      <span className="font-bold cursor-pointer">
+        {title}
+      </span>
+      <div className="flex float-right ml-20">
+        <PencilSquareIcon
+          className="h-5 w-5 mx-1 text-blue-500 cursor-pointer"
+          onClick={() => {
+            dispatch(
+              setEditedTask({
+                id: id,
+                title: title,
+                description: description,
+              })
+            )
+          }}
+        />
+        <TrashIcon
+          className="h-5 w-5 text-blue-500 cursor-pointer"
+          onClick={() => {
+            deleteTaskMutation.mutate(id)
+          }}
+        />
+      </div>
+    </li>
+  )
+}
+export const TaskItem = memo(TaskItemMemo)

--- a/react_farm/src/components/Todo.tsx
+++ b/react_farm/src/components/Todo.tsx
@@ -1,19 +1,74 @@
-import { ArrowRightOnRectangleIcon as LogoutIcon } from '@heroicons/react/24/solid';
-import { useProcessAuth } from '../hooks/useProcessAuth';
-import { useQueryTasks } from '../hooks/useQueryTasks';
-import { useQueryUser } from '../hooks/useQueryUser';
+import { FC, useState } from 'react'
+import { ArrowRightOnRectangleIcon as LogoutIcon } from '@heroicons/react/24/solid'
+import { ShieldCheckIcon } from '@heroicons/react/24/solid'
+import { useAppSelector, useAppDispatch } from '../app/hooks'
+import { setEditedTask, selectTask } from '../slices/appSlice'
+import { useProcessAuth } from '../hooks/useProcessAuth'
+import { useProcessTask } from '../hooks/useProcessTask'
+import { useQueryTasks } from '../hooks/useQueryTasks'
+import { useQueryUser } from '../hooks/useQueryUser'
+import { TaskItem } from './TaskItem'
 
-export const Todo = () => {
+export const Todo: FC = () => {
   const { logout } = useProcessAuth()
   const { data: dataUser } = useQueryUser()
   const { data: dataTasks, isLoading: isLoadingTasks } = useQueryTasks()
-
+  const { processTask } = useProcessTask()
+  const dispatch = useAppDispatch()
+  const editedTask = useAppSelector(selectTask)
   return (
     <div className="flex justify-center items-center flex-col min-h-screen text-gray-600 font-mono">
+      <div className="flex items-center">
+        <ShieldCheckIcon className="h-8 w-8 mr-3 text-green-500 cursor-pointer" />
+        <span className="text-center text-3xl font-extrabold">CRUD tasks</span>
+      </div>
+      <p className="my-3 text-sm">{dataUser?.email}</p>
       <LogoutIcon
         onClick={logout}
         className="h-7 w-7 mt-1 mb-5 text-blue-500 cursor-pointer"
       />
+      <form onSubmit={processTask}>
+        <input
+          className="mb-3 mr-3 px-3 py-2 border border-gray-300"
+          placeholder="title ?"
+          type="text"
+          onChange={(e) =>
+            dispatch(setEditedTask({ ...editedTask, title: e.target.value }))
+          }
+          value={editedTask.title}
+        />
+        <input
+          className="mb-3 px-3 py-2 border border-gray-300"
+          placeholder="description ?"
+          type="text"
+          onChange={(e) =>
+            dispatch(
+              setEditedTask({ ...editedTask, description: e.target.value })
+            )
+          }
+          value={editedTask.description}
+        />
+        <button
+          className="disabled:opacity-40 mx-3 py-2 px-3 text-white bg-indigo-600 rounded"
+          disabled={!editedTask.title || !editedTask.description}
+        >
+          {editedTask.id === '' ? 'Create' : 'Update'}
+        </button>
+      </form>
+      {isLoadingTasks ? (
+        <p>Loading...</p>
+      ) : (
+        <ul className="my-5">
+          {dataTasks?.map((task) => (
+            <TaskItem
+              key={task.id}
+              id={task.id}
+              title={task.title}
+              description={task.description}
+            />
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/react_farm/src/hooks/useMutateTask.ts
+++ b/react_farm/src/hooks/useMutateTask.ts
@@ -1,0 +1,108 @@
+import axios from "axios";
+import { useAppDispatch } from "../app/hooks";
+import { useQueryClient, useMutation } from "react-query";
+import { resetEditedTask, toggleCsrfState } from "../slices/appSlice";
+import { Task } from "../types/types";
+import { useNavigate } from "react-router-dom";
+
+export const useMutateTask = () => {
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+  const queryClient = useQueryClient()
+
+  const createTaskMutation = useMutation((task: Omit<Task, "id">) =>
+    axios.post<Task>(`${process.env.REACT_APP_API_URL}/todo`, task, {
+      withCredentials: true,
+    }),
+    {
+      onSuccess: (res) => {
+        const previousTodos = queryClient.getQueryData<Task[]>("tasks")
+        if (previousTodos) {
+          queryClient.setQueryData("tasks", [...previousTodos, res.data])
+        }
+        dispatch(resetEditedTask())
+      },
+      onError: (err: any) => {
+        alert(`${err.response.data.detail}\n${err.message}`)
+        if (
+          err.response.data.detail === "The JWT has expired" ||
+          err.response.data.detail === "The CSRF token has expired."
+        ) {
+          dispatch(toggleCsrfState())
+          dispatch(resetEditedTask())
+          navigate("/")
+        }
+      },
+    }
+  )
+  const updateTaskMutation = useMutation((task: Task) =>
+    axios.put<Task>(
+      `${process.env.REACT_APP_API_URL}/todo/${task.id}`,
+      {
+        title: task.title,
+        description: task.description,
+      },
+      {
+        withCredentials: true,
+      }
+    ),
+    {
+      onSuccess: (res, variables) => {
+        const previousTodos = queryClient.getQueryData<Task[]>("tasks")
+        if (previousTodos) {
+          queryClient.setQueryData<Task[]>(
+            "tasks",
+            previousTodos.map((task) =>
+              task.id === variables.id ? res.data : task
+            )
+          )
+        }
+        dispatch(resetEditedTask())
+      },
+      onError: (err: any) => {
+        alert(`${err.response.data.detail}\n${err.message}`)
+        if (
+          err.response.data.detail === "The JWT has expired" ||
+          err.response.data.detail === "The CSRF token has expired."
+        ) {
+          dispatch(toggleCsrfState())
+          dispatch(resetEditedTask())
+          navigate("/")
+        }
+      },
+    }
+  )
+  const deleteTaskMutation = useMutation((id: string) =>
+    axios.delete(`${process.env.REACT_APP_API_URL}/todo/${id}`, {
+      withCredentials: true,
+    }),
+    {
+      onSuccess: (res, variables) => {
+        const previousTodos = queryClient.getQueryData<Task[]>("tasks")
+        if (previousTodos) {
+          queryClient.setQueryData<Task[]>(
+            "tasks",
+            previousTodos.filter((task) => task.id !== variables)
+          )
+        }
+        dispatch(resetEditedTask())
+      },
+      onError: (err: any) => {
+        alert(`${err.response.data.detail}\n${err.message}`)
+        if (
+          err.response.data.detail === "The JWT has expired" ||
+          err.response.data.detail === "The CSRF token has expired."
+        ) {
+          dispatch(toggleCsrfState())
+          dispatch(resetEditedTask())
+          navigate("/")
+        }
+      },
+    }
+  )
+  return {
+    createTaskMutation,
+    updateTaskMutation,
+    deleteTaskMutation,
+  }
+}

--- a/react_farm/src/hooks/useProcessTask.ts
+++ b/react_farm/src/hooks/useProcessTask.ts
@@ -1,0 +1,21 @@
+import { FormEvent } from "react"
+import { useAppSelector } from "../app/hooks"
+import { useMutateTask } from "../hooks/useMutateTask"
+import { selectTask } from "../slices/appSlice"
+
+export const useProcessTask = () => {
+  const editedTask = useAppSelector(selectTask)
+  const { createTaskMutation, updateTaskMutation } = useMutateTask()
+  const processTask = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (editedTask.id === "")
+      createTaskMutation.mutate({
+        title: editedTask.title,
+        description: editedTask.description,
+      })
+    else {
+      updateTaskMutation.mutate(editedTask)
+    }
+  }
+  return { processTask }
+}


### PR DESCRIPTION
### 関連するIssue
close #16 

### 説明
ログインするとtodoを全件取得し表示する画面の作成。
保存・編集・削除ができる

### 上記追加以外の変更点
特になし

### 確認したこと
- ログイン時、登録してあるタスクが全て表示され、ボタンの初期表示がCreateであること
- `title`と`description`を入力し、Createボタンを押すと新しくタスクが登録される
- 登録済タスク横にある鉛筆ボタンを押すと、`title`と`description`に内容が表示され、ボタンがUpdateに変更される
  - 内容を変更し、`Update`を押すと更新される
- 登録済タスク横にあるごみ箱ボタンを押すと、該当タスクが削除される
